### PR TITLE
Should use main for a query

### DIFF
--- a/.github/actions/releases/index.js
+++ b/.github/actions/releases/index.js
@@ -85,7 +85,7 @@ const getMergedPRs = async (
   const lastReleaseTime = lastRelease.created_at;
   const newReleaseTime = finalCommitInNewRelease.data.commit.committer.date;
 
-  const q = `repo:${owner}/${repo} merged:${lastReleaseTime}..${newReleaseTime} base:master`;
+  const q = `repo:${owner}/${repo} merged:${lastReleaseTime}..${newReleaseTime} base:main`;
   const prSearchResults = await octokit.rest.search.issuesAndPullRequests({
     q,
   });


### PR DESCRIPTION
# Summary
Evergreen's SegmentedControl is going to be deprecated in the next version.
Implemented custom SegmentedControl that is based on evergreen's `Group` and `Button` components.
That approach saves us from reimplementing the `onChange` handler logic in many places and protects us from component deprecation.

## Shortcut story Link(s)
https://app.shortcut.com/maestroqa/story/5678987654567/deprecate-segmentedcontrol-haha

## Instructions to test or replicate
There are multiple affected places: